### PR TITLE
Added equality logic and tests to dates and addresses.

### DIFF
--- a/GeneGenie.Gedcom.Tests/Address/GedcomAddressComparisonTest.cs
+++ b/GeneGenie.Gedcom.Tests/Address/GedcomAddressComparisonTest.cs
@@ -1,10 +1,23 @@
-﻿namespace GeneGenie.Gedcom.Address.Tests
+﻿// <copyright file="GedcomAddressComparisonTest.cs" company="GeneGenie.com">
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see http:www.gnu.org/licenses/ .
+//
+// </copyright>
+
+namespace GeneGenie.Gedcom.Address.Tests
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
+    using Enums;
     using Xunit;
 
     /// <summary>
@@ -12,13 +25,246 @@
     /// </summary>
     public class GedcomAddressComparisonTest
     {
+        [Fact]
+        private void Address_is_not_equal_to_null()
+        {
+            var address = new GedcomAddress();
 
+            Assert.False(address.Equals(null));
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_address_line_is_different()
+        {
+            var address1 = new GedcomAddress { AddressLine = "1234 Main St Anywhere" };
+            var address2 = new GedcomAddress { AddressLine = "6789 Side St Somewhere" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_address_line1_is_different()
+        {
+            var address1 = new GedcomAddress { AddressLine1 = "1234 Main St" };
+            var address2 = new GedcomAddress { AddressLine1 = "6789 Side St" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_address_line2_is_different()
+        {
+            var address1 = new GedcomAddress { AddressLine2 = "Anywhere" };
+            var address2 = new GedcomAddress { AddressLine2 = "Somewhere" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_address_line3_is_different()
+        {
+            var address1 = new GedcomAddress { AddressLine3 = "PO Box 1234" };
+            var address2 = new GedcomAddress { AddressLine3 = "Apt 123" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_change_date_is_different()
+        {
+            var address1 = new GedcomAddress { ChangeDate = new GedcomChangeDate(null) { Date1 = "01 Jan 1900" } };
+            var address2 = new GedcomAddress { ChangeDate = new GedcomChangeDate(null) { Date1 = "01 Jan 2000" } };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_equal_if_change_date_is_same()
+        {
+            var address1 = new GedcomAddress { ChangeDate = new GedcomChangeDate(null) { Date1 = "01 Jan 2000" } };
+            var address2 = new GedcomAddress { ChangeDate = new GedcomChangeDate(null) { Date1 = "01 Jan 2000" } };
+
+            Assert.True(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_city_is_different()
+        {
+            var address1 = new GedcomAddress { City = "City One" };
+            var address2 = new GedcomAddress { City = "City Two" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_country_is_different()
+        {
+            var address1 = new GedcomAddress { Country = "USA" };
+            var address2 = new GedcomAddress { Country = "Canada" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_email1_is_different()
+        {
+            var address1 = new GedcomAddress { Email1 = "email_one@domain" };
+            var address2 = new GedcomAddress { Email1 = "email_two@another_domain" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_email2_is_different()
+        {
+            var address1 = new GedcomAddress { Email2 = "email_one@domain" };
+            var address2 = new GedcomAddress { Email2 = "email_two@another_domain" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_email3_is_different()
+        {
+            var address1 = new GedcomAddress { Email3 = "email_one@domain" };
+            var address2 = new GedcomAddress { Email3 = "email_two@another_domain" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_fax1_is_different()
+        {
+            var address1 = new GedcomAddress { Fax1 = "123-4567" };
+            var address2 = new GedcomAddress { Fax1 = "999-9999" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_fax2_is_different()
+        {
+            var address1 = new GedcomAddress { Fax2 = "123-4567" };
+            var address2 = new GedcomAddress { Fax2 = "999-9999" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_fax3_is_different()
+        {
+            var address1 = new GedcomAddress { Fax3 = "123-4567" };
+            var address2 = new GedcomAddress { Fax3 = "999-9999" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_phone1_is_different()
+        {
+            var address1 = new GedcomAddress { Phone1 = "123-4567" };
+            var address2 = new GedcomAddress { Phone1 = "999-9999" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_phone2_is_different()
+        {
+            var address1 = new GedcomAddress { Phone2 = "123-4567" };
+            var address2 = new GedcomAddress { Phone2 = "999-9999" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_phone3_is_different()
+        {
+            var address1 = new GedcomAddress { Phone3 = "123-4567" };
+            var address2 = new GedcomAddress { Phone3 = "999-9999" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_post_code_is_different()
+        {
+            var address1 = new GedcomAddress { PostCode = "12345" };
+            var address2 = new GedcomAddress { PostCode = "67890" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_state_is_different()
+        {
+            var address1 = new GedcomAddress { State = "VA" };
+            var address2 = new GedcomAddress { State = "CA" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_www1_is_different()
+        {
+            var address1 = new GedcomAddress { Www1 = "www.some-site.com" };
+            var address2 = new GedcomAddress { Www1 = "www.another-site.edu" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_www2_is_different()
+        {
+            var address1 = new GedcomAddress { Www2 = "www.some-site.com" };
+            var address2 = new GedcomAddress { Www2 = "www.another-site.edu" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Address_is_not_equal_if_www3_is_different()
+        {
+            var address1 = new GedcomAddress { Www3 = "www.some-site.com" };
+            var address2 = new GedcomAddress { Www3 = "www.another-site.edu" };
+
+            Assert.False(address1.CompareTo(address2) == 0);
+        }
+
+        [Fact]
+        private void Addresses_are_equal_if_all_facts_are_equal()
+        {
+            var address1 = GenerateComparableAddress();
+            var address2 = GenerateComparableAddress();
+
+            Assert.True(address1.CompareTo(address2) == 0);
+        }
 
         private GedcomAddress GenerateComparableAddress()
         {
             return new GedcomAddress
             {
-              
+                AddressLine = "1234 Main St Anywhere PO Box 1234",
+                AddressLine1 = "1234 Main St",
+                AddressLine2 = "Anywhere",
+                AddressLine3 = "PO Box 1234",
+                ChangeDate = new GedcomChangeDate(null) { DateType = GedcomDateType.Julian },
+                City = "City One",
+                Country = "USA",
+                Email1 = "email1e@domain",
+                Email2 = "email2@another_domain",
+                Email3 = "email3@yet_another_domain",
+                Fax1 = "333-3333",
+                Fax2 = "666-6666",
+                Fax3 = "999-9999",
+                Phone1 = "111-1111",
+                Phone2 = "222-2222",
+                Phone3 = "333-3333",
+                PostCode = "12345",
+                State = "VA",
+                Www1 = "www.some-site.com",
+                Www2 = "www.some-other-site.edu",
+                Www3 = "www.yet-another-site.net"
             };
         }
     }

--- a/GeneGenie.Gedcom.Tests/Address/GedcomAddressComparisonTest.cs
+++ b/GeneGenie.Gedcom.Tests/Address/GedcomAddressComparisonTest.cs
@@ -1,0 +1,25 @@
+﻿namespace GeneGenie.Gedcom.Address.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Xunit;
+
+    /// <summary>
+    /// Tests for equality of addresses.
+    /// </summary>
+    public class GedcomAddressComparisonTest
+    {
+
+
+        private GedcomAddress GenerateComparableAddress()
+        {
+            return new GedcomAddress
+            {
+              
+            };
+        }
+    }
+}

--- a/GeneGenie.Gedcom.Tests/Date/GedcomDateCompareTest.cs
+++ b/GeneGenie.Gedcom.Tests/Date/GedcomDateCompareTest.cs
@@ -87,5 +87,75 @@ namespace GeneGenie.Gedcom.Date.Tests
 
             Assert.True(lessThan);
         }
+
+        [Theory]
+        [InlineData("1 Jan 1900", "1 Jan 2000")]
+        private void Compare_by_date_returns_less_than_zero_when_first_date_is_earlier(string dateAText, string dateBText)
+        {
+            var dateA = CreateDate(dateAText);
+            var dateB = CreateDate(dateBText);
+
+            var result = GedcomDate.CompareByDate(dateA, dateB);
+
+            Assert.True(result == -1);
+        }
+
+        [Theory]
+        [InlineData("1 Jan 2000", "1 Jan 1900")]
+        private void Compare_by_date_returns_greater_than_zero_when_second_date_is_earlier(string dateAText, string dateBText)
+        {
+            var dateA = CreateDate(dateAText);
+            var dateB = CreateDate(dateBText);
+
+            var result = GedcomDate.CompareByDate(dateA, dateB);
+
+            Assert.True(result == 1);
+        }
+
+        [Theory]
+        [InlineData("1 Jan 1900", "1 Jan 1900")]
+        private void Compare_by_date_returns_zero_when_dates_are_equal(string dateAText, string dateBText)
+        {
+            var dateA = CreateDate(dateAText);
+            var dateB = CreateDate(dateBText);
+
+            var result = GedcomDate.CompareByDate(dateA, dateB);
+
+            Assert.True(result == 0);
+        }
+
+        [Fact]
+        private void Compare_by_date_returns_zero_when_dates_are_both_null()
+        {
+            var dateA = new GedcomDate();
+            var dateB = new GedcomDate();
+
+            var result = GedcomDate.CompareByDate(dateA, dateB);
+
+            Assert.True(result == 0);
+        }
+
+        [Fact]
+        private void Compare_by_date_returns_less_than_zero_when_only_first_date_is_null()
+        {
+            var dateA = new GedcomDate();
+            var dateB = CreateDate("1 Jan 1900");
+
+            var result = GedcomDate.CompareByDate(dateA, dateB);
+
+            Assert.True(result == -1);
+        }
+
+        [Fact]
+        private void Compare_by_date_returns_greater_than_zero_when_only_second_date_is_null()
+        {
+            var dateA = CreateDate("1 Jan 1900");
+            var dateB = new GedcomDate();
+
+            var result = GedcomDate.CompareByDate(dateA, dateB);
+
+            Assert.True(result == 1);
+        }
+
     }
 }

--- a/GeneGenie.Gedcom.Tests/Date/GedcomDateCompareTest.cs
+++ b/GeneGenie.Gedcom.Tests/Date/GedcomDateCompareTest.cs
@@ -45,6 +45,13 @@ namespace GeneGenie.Gedcom.Date.Tests
             yield return new object[] { "Jan 1900", "1900" };
         }
 
+        private static IEnumerable<object> GetDistinctDateRangesAndExpectedSortValue()
+        {
+            yield return new object[] { "1 Jan 1900", "1 Jan 2000", -1 };
+            yield return new object[] { "1 Jan 1900", "1 Jan 1900", 0 };
+            yield return new object[] { "1 Jan 2000", "1 Jan 1900", 1 };
+        }
+
         private static GedcomDate CreateDate(string dateText)
         {
             var date = new GedcomDate();
@@ -89,39 +96,15 @@ namespace GeneGenie.Gedcom.Date.Tests
         }
 
         [Theory]
-        [InlineData("1 Jan 1900", "1 Jan 2000")]
-        private void Compare_by_date_returns_less_than_zero_when_first_date_is_earlier(string dateAText, string dateBText)
+        [MemberData(nameof(GetDistinctDateRangesAndExpectedSortValue))]
+        private void Compare_by_date_sorts_two_dates_correctly(string dateAText, string dateBText, int expectedSortValue)
         {
             var dateA = CreateDate(dateAText);
             var dateB = CreateDate(dateBText);
 
-            var result = GedcomDate.CompareByDate(dateA, dateB);
+            var actualSortValue = GedcomDate.CompareByDate(dateA, dateB);
 
-            Assert.True(result == -1);
-        }
-
-        [Theory]
-        [InlineData("1 Jan 2000", "1 Jan 1900")]
-        private void Compare_by_date_returns_greater_than_zero_when_second_date_is_earlier(string dateAText, string dateBText)
-        {
-            var dateA = CreateDate(dateAText);
-            var dateB = CreateDate(dateBText);
-
-            var result = GedcomDate.CompareByDate(dateA, dateB);
-
-            Assert.True(result == 1);
-        }
-
-        [Theory]
-        [InlineData("1 Jan 1900", "1 Jan 1900")]
-        private void Compare_by_date_returns_zero_when_dates_are_equal(string dateAText, string dateBText)
-        {
-            var dateA = CreateDate(dateAText);
-            var dateB = CreateDate(dateBText);
-
-            var result = GedcomDate.CompareByDate(dateA, dateB);
-
-            Assert.True(result == 0);
+            Assert.Equal(expectedSortValue, actualSortValue);
         }
 
         [Fact]
@@ -157,5 +140,16 @@ namespace GeneGenie.Gedcom.Date.Tests
             Assert.True(result == 1);
         }
 
+        [Theory]
+        [MemberData(nameof(GetDistinctDateRangesAndExpectedSortValue))]
+        private void CompareTo_sorts_two_dates_correctly(string dateAText, string dateBText, int expectedSortValue)
+        {
+            var dateA = CreateDate(dateAText);
+            var dateB = CreateDate(dateBText);
+
+            var actualSortValue = dateA.CompareTo(dateB);
+
+            Assert.Equal(expectedSortValue, actualSortValue);
+        }
     }
 }

--- a/GeneGenie.Gedcom.Tests/Date/GedcomDateCompareTest.cs
+++ b/GeneGenie.Gedcom.Tests/Date/GedcomDateCompareTest.cs
@@ -108,7 +108,7 @@ namespace GeneGenie.Gedcom.Date.Tests
         }
 
         [Fact]
-        private void Compare_by_date_returns_zero_when_dates_are_both_null()
+        private void Compare_by_date_returns_zero_when_internal_date_values_are_both_null()
         {
             var dateA = new GedcomDate();
             var dateB = new GedcomDate();
@@ -119,7 +119,7 @@ namespace GeneGenie.Gedcom.Date.Tests
         }
 
         [Fact]
-        private void Compare_by_date_returns_less_than_zero_when_only_first_date_is_null()
+        private void Compare_by_date_returns_less_than_zero_when_only_first_internal_date_is_null()
         {
             var dateA = new GedcomDate();
             var dateB = CreateDate("1 Jan 1900");
@@ -130,10 +130,43 @@ namespace GeneGenie.Gedcom.Date.Tests
         }
 
         [Fact]
-        private void Compare_by_date_returns_greater_than_zero_when_only_second_date_is_null()
+        private void Compare_by_date_returns_greater_than_zero_when_only_second_internal_date_is_null()
         {
             var dateA = CreateDate("1 Jan 1900");
             var dateB = new GedcomDate();
+
+            var result = GedcomDate.CompareByDate(dateA, dateB);
+
+            Assert.True(result == 1);
+        }
+
+        [Fact]
+        private void Compare_by_date_returns_zero_when_dates_are_both_null()
+        {
+            GedcomDate dateA = null;
+            GedcomDate dateB = null;
+
+            var result = GedcomDate.CompareByDate(dateA, dateB);
+
+            Assert.True(result == 0);
+        }
+
+        [Fact]
+        private void Compare_by_date_returns_less_than_zero_when_only_first_date_is_null()
+        {
+            GedcomDate dateA = null;
+            GedcomDate dateB = new GedcomDate();
+
+            var result = GedcomDate.CompareByDate(dateA, dateB);
+
+            Assert.True(result == -1);
+        }
+
+        [Fact]
+        private void Compare_by_date_returns_greater_than_zero_when_only_second_date_is_null()
+        {
+            GedcomDate dateA = new GedcomDate();
+            GedcomDate dateB = null;
 
             var result = GedcomDate.CompareByDate(dateA, dateB);
 

--- a/GeneGenie.Gedcom.Tests/GeneGenie.Gedcom.Tests.csproj
+++ b/GeneGenie.Gedcom.Tests/GeneGenie.Gedcom.Tests.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Date\GedcomDateNullEqualTest.cs" />
     <Compile Include="Date\GedcomDatePeriodTest.cs" />
     <Compile Include="Date\GedcomDateParseTest.cs" />
+    <Compile Include="Address\GedcomAddressComparisonTest.cs" />
     <Compile Include="GedcomDeleteTest.cs" />
     <Compile Include="GedcomIdentTest.cs" />
     <Compile Include="GedcomToDoTests.cs" />

--- a/GeneGenie.Gedcom.Tests/Individuals/GedcomFamilyLinkComparisonTest.cs
+++ b/GeneGenie.Gedcom.Tests/Individuals/GedcomFamilyLinkComparisonTest.cs
@@ -1,4 +1,21 @@
-﻿namespace GeneGenie.Gedcom.Tests.Individuals
+﻿// <copyright file="GedcomFamilyLinkComparisonTest.cs" company="GeneGenie.com">
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see http:www.gnu.org/licenses/ .
+//
+// </copyright>
+
+namespace GeneGenie.Gedcom.Tests.Individuals
 {
     using Enums;
     using Xunit;

--- a/GeneGenie.Gedcom.Tests/Individuals/GedcomFamilyLinkComparisonTest.cs
+++ b/GeneGenie.Gedcom.Tests/Individuals/GedcomFamilyLinkComparisonTest.cs
@@ -8,19 +8,6 @@
     /// </summary>
     public class GedcomFamilyLinkComparisonTest
     {
-        private readonly GedcomDatabase gedcomDb;
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GedcomFamilyLinkComparisonTest"/> class.
-        /// </summary>
-        /// <remarks>
-        /// Test suite for the <see cref="GedcomFamilyLinkComparisonTest"/> class.
-        /// </remarks>
-        public GedcomFamilyLinkComparisonTest()
-        {
-            gedcomDb = new GedcomDatabase();
-        }
-
         [Fact]
         private void Family_link_is_not_equal_to_null_test()
         {

--- a/GeneGenie.Gedcom/GedcomAddress.cs
+++ b/GeneGenie.Gedcom/GedcomAddress.cs
@@ -485,49 +485,131 @@ namespace GeneGenie.Gedcom
                 return 1;
             }
 
-            var compare = otherAddress.AddressLine.CompareTo(AddressLine);
+            var compare = string.Compare(AddressLine, otherAddress.AddressLine);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = otherAddress.AddressLine1.CompareTo(AddressLine1);
+            compare = string.Compare(AddressLine1, otherAddress.AddressLine1);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = otherAddress.AddressLine2.CompareTo(AddressLine2);
+            compare = string.Compare(AddressLine2, otherAddress.AddressLine2);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = otherAddress.AddressLine3.CompareTo(AddressLine3);
+            compare = string.Compare(AddressLine3, otherAddress.AddressLine3);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = otherAddress.ChangeDate.CompareTo(ChangeDate);
+            compare = GedcomDate.CompareByDate(ChangeDate, otherAddress.ChangeDate);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = otherAddress.AddressLine3.CompareTo(AddressLine3);
+            compare = string.Compare(City, otherAddress.City);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = otherAddress.AddressLine3.CompareTo(AddressLine3);
+            compare = string.Compare(Country, otherAddress.Country);
             if (compare != 0)
             {
                 return compare;
             }
 
+            compare = string.Compare(Email1, otherAddress.Email1);
+            if (compare != 0)
+            {
+                return compare;
+            }
 
+            compare = string.Compare(Email2, otherAddress.Email2);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Email3, otherAddress.Email3);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Fax1, otherAddress.Fax1);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Fax2, otherAddress.Fax2);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Fax3, otherAddress.Fax3);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Phone1, otherAddress.Phone1);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Phone2, otherAddress.Phone2);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Phone3, otherAddress.Phone3);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(PostCode, otherAddress.PostCode);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(State, otherAddress.State);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Www1, otherAddress.Www1);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Www2, otherAddress.Www2);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Www3, otherAddress.Www3);
+            if (compare != 0)
+            {
+                return compare;
+            }
 
             return compare;
         }
@@ -1097,11 +1179,6 @@ namespace GeneGenie.Gedcom
                     System.Diagnostics.Debug.WriteLine("Truncating Www3");
                 }
             }
-        }
-
-        public override bool Equals(object obj)
-        {
-            return base.Equals(obj as GedcomAddress);
         }
 
         private void Changed()

--- a/GeneGenie.Gedcom/GedcomAddress.cs
+++ b/GeneGenie.Gedcom/GedcomAddress.cs
@@ -26,7 +26,7 @@ namespace GeneGenie.Gedcom
     /// <summary>
     /// Stores details of an address
     /// </summary>
-    public class GedcomAddress
+    public class GedcomAddress : IComparable<GedcomAddress>, IComparable, IEquatable<GedcomAddress>
     {
         private string addressLine;
         private string addressLine1;
@@ -469,6 +469,91 @@ namespace GeneGenie.Gedcom
                     Changed();
                 }
             }
+        }
+
+        /// <summary>
+        /// Compares the current and passed-in address to see if they are the same.
+        /// </summary>
+        /// <param name="otherAddress">The address to compare the current instance against.</param>
+        /// <returns>
+        /// A 32-bit signed integer that indicates whether this instance precedes, follows, or appears in the same position in the sort order as the value parameter.
+        /// </returns>
+        public int CompareTo(GedcomAddress otherAddress)
+        {
+            if (otherAddress == null)
+            {
+                return 1;
+            }
+
+            var compare = otherAddress.AddressLine.CompareTo(AddressLine);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = otherAddress.AddressLine1.CompareTo(AddressLine1);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = otherAddress.AddressLine2.CompareTo(AddressLine2);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = otherAddress.AddressLine3.CompareTo(AddressLine3);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = otherAddress.ChangeDate.CompareTo(ChangeDate);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = otherAddress.AddressLine3.CompareTo(AddressLine3);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = otherAddress.AddressLine3.CompareTo(AddressLine3);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+
+
+            return compare;
+        }
+
+        /// <summary>
+        /// Compares the current and passed-in address to see if they are the same.
+        /// </summary>
+        /// <param name="obj">The object to compare the current instance against.</param>
+        /// <returns>
+        /// A 32-bit signed integer that indicates whether this instance precedes, follows, or appears in the same position in the sort order as the value parameter.
+        /// </returns>
+        public int CompareTo(object obj)
+        {
+            return CompareTo(obj as GedcomAddress);
+        }
+
+        /// <summary>
+        /// Compares the current and passed-in address to see if they are the same.
+        /// </summary>
+        /// <param name="otherAddress">The address to compare the current instance against.</param>
+        /// <returns>
+        /// True if they match, False otherwise.
+        /// </returns>
+        public bool Equals(GedcomAddress otherAddress)
+        {
+            return CompareTo(otherAddress) == 0;
         }
 
         /// <summary>

--- a/GeneGenie.Gedcom/GedcomDate.cs
+++ b/GeneGenie.Gedcom/GedcomDate.cs
@@ -28,7 +28,7 @@ namespace GeneGenie.Gedcom
     /// <summary>
     /// Defines a date, allowing partial dates, date ranges etc.
     /// </summary>
-    public class GedcomDate : GedcomRecord
+    public class GedcomDate : GedcomRecord, IComparable, IComparable<GedcomDate>, IEquatable<GedcomDate>
     {
         private GedcomDateType dateType;
         private GedcomDatePeriod datePeriod;
@@ -383,7 +383,7 @@ namespace GeneGenie.Gedcom
         /// </returns>
         public override bool IsEquivalentTo(object obj)
         {
-            return CompareByDate(this, obj as GedcomDate) == 0;
+            return CompareTo(obj as GedcomDate) == 0;
         }
 
         /// <summary>
@@ -396,6 +396,36 @@ namespace GeneGenie.Gedcom
         public override bool Equals(object obj)
         {
             return this == (GedcomDate)obj;
+        }
+
+        /// <summary>
+        /// Compares the current and passed-in object to see if they are the same.
+        /// </summary>
+        /// <param name="obj">The object to compare the current instance against.</param>
+        /// <returns>A 32-bit signed integer that indicates whether this instance precedes, follows, or appears in the same position in the sort order as the value parameter.</returns>
+        public int CompareTo(object obj)
+        {
+            return CompareTo(obj as GedcomDate);
+        }
+
+        /// <summary>
+        /// Compares the current and passed-in date to see if they are the same.
+        /// </summary>
+        /// <param name="otherDate">The date to compare the current instance against.</param>
+        /// <returns>A 32-bit signed integer that indicates whether this instance precedes, follows, or appears in the same position in the sort order as the value parameter.</returns>
+        public int CompareTo(GedcomDate otherDate)
+        {
+            return CompareByDate(this, otherDate);
+        }
+
+        /// <summary>
+        /// Compares the current and passed-in date to see if they are the same.
+        /// </summary>
+        /// <param name="otherDate">The date to compare the current instance against.</param>
+        /// <returns>True if they match, False otherwise.</returns>
+        public bool Equals(GedcomDate otherDate)
+        {
+            return CompareTo(otherDate) == 0;
         }
 
         /// <inheritdoc/>

--- a/GeneGenie.Gedcom/GedcomDate.cs
+++ b/GeneGenie.Gedcom/GedcomDate.cs
@@ -355,6 +355,22 @@ namespace GeneGenie.Gedcom
         /// <returns>0 if equal, -1 if datea less than dateb, else 1.</returns>
         public static int CompareByDate(GedcomDate datea, GedcomDate dateb)
         {
+            bool anull = Equals(datea, null);
+            bool bnull = Equals(dateb, null);
+
+            if (anull && bnull)
+            {
+                return 0;
+            }
+            else if (anull)
+            {
+                return -1;
+            }
+            else if (bnull)
+            {
+                return 1;
+            }
+
             int ret = CompareNullableDateTime(datea.DateTime1, dateb.DateTime1);
 
             if (ret == 0)

--- a/GeneGenie.Gedcom/GedcomDate.cs
+++ b/GeneGenie.Gedcom/GedcomDate.cs
@@ -425,7 +425,7 @@ namespace GeneGenie.Gedcom
         /// <returns>True if they match, False otherwise.</returns>
         public bool Equals(GedcomDate otherDate)
         {
-            return CompareTo(otherDate) == 0;
+            return this == otherDate;
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
Ref https://github.com/TheGeneGenieProject/GeneGenie.Gedcom/issues/10

- Implemented `IComparable` and `IEquatable` on `GedcomDate` and `GedcomAddress`.
- Added logic to `GedcomAddress` class to determine equality.
- Removed "override bool Equals" from `GedcomAddress` in favor of comparing values over reference.
- Added many tests around `GedcomAddress` to test equality of various fields.
- Added logic to `GedcomDate.CompareByDate` that handles null dates.
 - _A null date is ordered before a non-null date, two null dates are equal._
 - _Realized this could be an issue when creating tests around the class._
- Added copyright notice to `GedcomFamilyLinkComparisonTest` file.
- Added more tests to `GedcomDateCompareTest` class.
- Removed unused instance of `GedcomDatabase` from `FamilyLink` tests.