### PR TITLE
Fix Various Compile Warnings

### DIFF
--- a/GeneGenie.Gedcom.Reports/GedcomIndividualReport.cs
+++ b/GeneGenie.Gedcom.Reports/GedcomIndividualReport.cs
@@ -131,9 +131,9 @@ namespace GeneGenie.Gedcom.Reports
             }
             else
             {
-                foreach (GedcomIndividualRecord indi in Database.Individuals)
+                foreach (GedcomIndividualRecord gedcomIndividualRecord in Database.Individuals)
                 {
-                    AppendIndividualDetails(indi, root, 0);
+                    AppendIndividualDetails(gedcomIndividualRecord, root, 0);
                 }
 
                 foreach (GedcomSourceRecord source in Database.Sources)

--- a/GeneGenie.Gedcom/Enums/GedcomEventType.cs
+++ b/GeneGenie.Gedcom/Enums/GedcomEventType.cs
@@ -156,7 +156,7 @@ namespace GeneGenie.Gedcom.Enums
         ADOP,
 
         /// <summary>
-        ///Baptism
+        /// Baptism
         /// </summary>
         BAPM,
 

--- a/GeneGenie.Gedcom/GedcomIndividualEvent.cs
+++ b/GeneGenie.Gedcom/GedcomIndividualEvent.cs
@@ -22,7 +22,7 @@
 namespace GeneGenie.Gedcom
 {
 
-#if (!XML_NODE_UNDEFINED)
+#if !XML_NODE_UNDEFINED
     using System.Xml;
 #endif
 
@@ -193,7 +193,7 @@ namespace GeneGenie.Gedcom
             }
         }
 
-#if(!XML_NODE_UNDEFINED)
+#if !XML_NODE_UNDEFINED
         /// <summary>
         /// Generates the pers information XML.
         /// </summary>

--- a/GeneGenie.Gedcom/GedcomIndividualEvent.cs
+++ b/GeneGenie.Gedcom/GedcomIndividualEvent.cs
@@ -21,7 +21,6 @@
 
 namespace GeneGenie.Gedcom
 {
-
 #if !XML_NODE_UNDEFINED
     using System.Xml;
 #endif

--- a/GeneGenie.Gedcom/GedcomIndividualRecord.cs
+++ b/GeneGenie.Gedcom/GedcomIndividualRecord.cs
@@ -333,7 +333,7 @@ namespace GeneGenie.Gedcom
         }
 
         /// <summary>
-        /// Get the list of aliases.
+        /// Gets the list of aliases.
         /// </summary>
         /// <value>
         /// The list of aliases.

--- a/GeneGenie.Gedcom/GedcomIndividualRecord.cs
+++ b/GeneGenie.Gedcom/GedcomIndividualRecord.cs
@@ -21,7 +21,6 @@
 
 namespace GeneGenie.Gedcom
 {
-
     using System;
     using System.Globalization;
     using System.IO;

--- a/GeneGenie.Gedcom/GedcomIndividualRecord.cs
+++ b/GeneGenie.Gedcom/GedcomIndividualRecord.cs
@@ -28,7 +28,7 @@ namespace GeneGenie.Gedcom
     using System.Linq;
     using Enums;
 
-#if (!XML_NODE_UNDEFINED)
+#if !XML_NODE_UNDEFINED
     using System.Xml;
 #endif
 
@@ -1185,7 +1185,7 @@ namespace GeneGenie.Gedcom
             return fam;
         }
 
-#if(!XML_NODE_UNDEFINED)
+#if !XML_NODE_UNDEFINED
         /// <summary>
         /// Generates the XML.
         /// </summary>

--- a/GeneGenie.Gedcom/GedcomIndividualRecord.cs
+++ b/GeneGenie.Gedcom/GedcomIndividualRecord.cs
@@ -1481,39 +1481,39 @@ namespace GeneGenie.Gedcom
 
             if (alia != null)
             {
-                foreach (string alia in Alia)
+                foreach (string aliaValue in Alia)
                 {
                     tw.Write(Environment.NewLine);
                     tw.Write(levelPlusOne);
                     tw.Write(" ALIA ");
                     tw.Write("@");
-                    tw.Write(alia);
+                    tw.Write(aliaValue);
                     tw.Write("@");
                 }
             }
 
             if (anci != null)
             {
-                foreach (string anci in Anci)
+                foreach (string anciValue in Anci)
                 {
                     tw.Write(Environment.NewLine);
                     tw.Write(levelPlusOne);
                     tw.Write(" ANCI ");
                     tw.Write("@");
-                    tw.Write(anci);
+                    tw.Write(anciValue);
                     tw.Write("@");
                 }
             }
 
             if (desi != null)
             {
-                foreach (string anci in Desi)
+                foreach (string desiValue in Desi)
                 {
                     tw.Write(Environment.NewLine);
                     tw.Write(levelPlusOne);
                     tw.Write(" DESI ");
                     tw.Write("@");
-                    tw.Write(anci);
+                    tw.Write(desiValue);
                     tw.Write("@");
                 }
             }

--- a/GeneGenie.Gedcom/Helpers/IndexedKeyCollection.cs
+++ b/GeneGenie.Gedcom/Helpers/IndexedKeyCollection.cs
@@ -140,7 +140,6 @@ namespace GeneGenie.Gedcom.Helpers
         public virtual bool Find(string str, int startIndex, int length, out int pos)
         {
             // TODO: Needs unit testing and benchmarking.
-
             bool found = false;
 
             int i = 0;


### PR DESCRIPTION
Fixed various warnings but not all. Several are still active but left because they have *TODO*  or NotImplementedException near them. Issue #32. 

| Severity | Code | Description | Project | File | Line | Suppression State |
| -------- | ----- | ------------ | ------- | --- | ---- | ------------------- |
| Warning | CS0162 | Unreachable code detected | GeneGenie.Gedcom | GeneGenie.Gedcom\GeneGenie.Gedcom\GedcomDate.cs | 636 | Active |
| Warning | CS0162 | Unreachable code detected | GeneGenie.Gedcom | GeneGenie.Gedcom\GeneGenie.Gedcom\GedcomDate.cs | 653 | Active |
| Warning | CS0169 | The field 'GedcomFamilyRecord.lDSSpouseSealings' is never used | GeneGenie.Gedcom | GeneGenie.Gedcom\GeneGenie.Gedcom\GedcomFamilyRecord.cs | 48 |	Active |
| Warning | CS0169 | The field 'GedcomIndividualRecord.lDSIndividualOrdinances' is never used	 | GeneGenie.Gedcom | GeneGenie.Gedcom\GeneGenie.Gedcom\GedcomIndividualRecord.cs | 47 | Active |

