### PR TITLE
More comparison and equality logic and tests.

### DIFF
--- a/GeneGenie.Gedcom.Tests/Address/GedcomAddressComparisonTest.cs
+++ b/GeneGenie.Gedcom.Tests/Address/GedcomAddressComparisonTest.cs
@@ -70,18 +70,9 @@ namespace GeneGenie.Gedcom.Address.Tests
         }
 
         [Fact]
-        private void Address_is_not_equal_if_change_date_is_different()
+        private void Address_is_equal_if_change_date_is_different()
         {
             var address1 = new GedcomAddress { ChangeDate = new GedcomChangeDate(null) { Date1 = "01 Jan 1900" } };
-            var address2 = new GedcomAddress { ChangeDate = new GedcomChangeDate(null) { Date1 = "01 Jan 2000" } };
-
-            Assert.False(address1.CompareTo(address2) == 0);
-        }
-
-        [Fact]
-        private void Address_is_equal_if_change_date_is_same()
-        {
-            var address1 = new GedcomAddress { ChangeDate = new GedcomChangeDate(null) { Date1 = "01 Jan 2000" } };
             var address2 = new GedcomAddress { ChangeDate = new GedcomChangeDate(null) { Date1 = "01 Jan 2000" } };
 
             Assert.True(address1.CompareTo(address2) == 0);

--- a/GeneGenie.Gedcom.Tests/GedcomVariationComparisonTest.cs
+++ b/GeneGenie.Gedcom.Tests/GedcomVariationComparisonTest.cs
@@ -1,0 +1,87 @@
+﻿// <copyright file="GedcomVariationComparisonTest.cs" company="GeneGenie.com">
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program. If not, see http:www.gnu.org/licenses/ .
+//
+// </copyright>
+
+namespace GeneGenie.Gedcom.Tests
+{
+    using Xunit;
+
+    /// <summary>
+    /// Tests for equality of addresses.
+    /// </summary>
+    public class GedcomVariationComparisonTest
+    {
+        [Fact]
+        private void CompareTo_does_not_return_zero_when_compared_to_null()
+        {
+            GedcomVariation var1 = new GedcomVariation();
+            GedcomVariation var2 = null;
+
+            Assert.False(var1.CompareTo(var2) == 0);
+        }
+
+        [Fact]
+        private void CompareTo_returns_zero_when_all_facts_are_equal()
+        {
+            GedcomVariation var1 = GenerateComparableVariation();
+            GedcomVariation var2 = GenerateComparableVariation();
+
+            Assert.True(var1.CompareTo(var2) == 0);
+        }
+
+        [Fact]
+        private void Equals_returns_true_when_all_facts_are_equal()
+        {
+            GedcomVariation var1 = GenerateComparableVariation();
+            GedcomVariation var2 = GenerateComparableVariation();
+
+            Assert.True(var1.Equals(var2));
+        }
+
+        [Fact]
+        private void CompareTo_does_not_return_zero_when_different_values()
+        {
+            GedcomVariation var1 = GenerateComparableVariation();
+            GedcomVariation var2 = GenerateComparableVariation();
+
+            var1.Value = "Value A";
+            var2.Value = "Value B";
+
+            Assert.False(var1.CompareTo(var2) == 0);
+        }
+
+        [Fact]
+        private void CompareTo_does_not_return_zero_when_different_varation_types()
+        {
+            GedcomVariation var1 = GenerateComparableVariation();
+            GedcomVariation var2 = GenerateComparableVariation();
+
+            var1.VariationType = "Varation Type A";
+            var2.VariationType = "Variation Type B";
+
+            Assert.False(var1.CompareTo(var2) == 0);
+        }
+
+        private GedcomVariation GenerateComparableVariation()
+        {
+            return new GedcomVariation
+            {
+                Value = "Some Value",
+                VariationType = "Some Variation Type"
+            };
+        }
+    }
+}

--- a/GeneGenie.Gedcom.Tests/GeneGenie.Gedcom.Tests.csproj
+++ b/GeneGenie.Gedcom.Tests/GeneGenie.Gedcom.Tests.csproj
@@ -147,6 +147,7 @@
     <Compile Include="GedcomDeleteTest.cs" />
     <Compile Include="GedcomIdentTest.cs" />
     <Compile Include="GedcomToDoTests.cs" />
+    <Compile Include="GedcomVariationComparisonTest.cs" />
     <Compile Include="HeinerEichmannAllTagsTest.cs" />
     <Compile Include="GedcomGraphTest.cs" />
     <Compile Include="Individuals\GedcomFamilyLinkComparisonTest.cs" />

--- a/GeneGenie.Gedcom.Tests/Individuals/GedcomNameComparisonTest.cs
+++ b/GeneGenie.Gedcom.Tests/Individuals/GedcomNameComparisonTest.cs
@@ -1,4 +1,4 @@
-// <copyright file="GedcomNameComparisonTest.cs" company="GeneGenie.com">
+﻿// <copyright file="GedcomNameComparisonTest.cs" company="GeneGenie.com">
 //
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU Affero General Public License as published by
@@ -38,6 +38,15 @@ namespace GeneGenie.Gedcom.Parser
         }
 
         [Fact]
+        private void Name_is_not_equal_to_null()
+        {
+            GedcomName name1 = new GedcomName();
+            GedcomName name2 = null;
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        [Fact]
         private void Longer_list_of_names_is_sorted_after_smaller_list()
         {
             var list1 = new List<GedcomName> { new GedcomName() };
@@ -53,6 +62,14 @@ namespace GeneGenie.Gedcom.Parser
             var list2 = new List<GedcomName> { new GedcomName() };
 
             Assert.Equal(-1, GedcomGenericListComparer.CompareListSortOrders(list1, list2));
+        }
+
+        private void Names_with_same_facts_are_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            Assert.Equal(name1, name2);
         }
 
         [Fact]
@@ -74,6 +91,75 @@ namespace GeneGenie.Gedcom.Parser
         }
 
         [Fact]
+        private void Different_types_are_not_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            name2.Type = string.Empty;
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        [Fact]
+        private void Different_phonetic_variations_are_not_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            name1.PhoneticVariations.Clear();
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        [Fact]
+        private void Different_romanized_variations_are_not_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            name1.RomanizedVariations.Clear();
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        [Fact]
+        private void Different_surnames_are_not_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            name1.Surname = "Smith";
+            name2.Surname = "Jones";
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        [Fact]
+        private void Different_prefixes_are_not_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            name1.Prefix = "Miss";
+            name2.Prefix = "Mrs";
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        [Fact]
+        private void Different_given_names_are_not_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            name1.Given = "Mary";
+            name2.Given = "Miriam";
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        [Fact]
         private void Different_casing_of_given_names_are_not_equal()
         {
             Assert.NotEqual(gedcomDb.NamedPerson("Ryan", null), gedcomDb.NamedPerson("ryan", null));
@@ -86,15 +172,91 @@ namespace GeneGenie.Gedcom.Parser
         }
 
         [Fact]
-        private void Different_given_names_are_not_equal()
-        {
-            Assert.NotEqual(gedcomDb.NamedPerson("Ryan", null), gedcomDb.NamedPerson("David", null));
-        }
-
-        [Fact]
         private void Same_given_names_are_equal()
         {
             Assert.Equal(gedcomDb.NamedPerson("Ryan", null), gedcomDb.NamedPerson("Ryan", null));
+        }
+
+        [Fact]
+        private void Different_surname_prefixes_are_not_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            name1.Surname = "Neu";
+            name2.Surname = string.Empty;
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        [Fact]
+        private void Different_suffixes_are_not_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            name1.Surname = "Smith";
+            name2.Surname = "Jones";
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        [Fact]
+        private void Different_nicks_are_not_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            name1.Nick = "Polly";
+            name2.Nick = "Molly";
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        [Fact]
+        private void Different_preferred_flags_are_not_equal()
+        {
+            var name1 = GenerateCompleteName();
+            var name2 = GenerateCompleteName();
+
+            name1.PreferredName = true;
+            name2.PreferredName = false;
+
+            Assert.NotEqual(name1, name2);
+        }
+
+        private GedcomName GenerateCompleteName()
+        {
+            var phoneticVariations =
+                new GedcomRecordList<GedcomVariation>
+                {
+                    new GedcomVariation { Value = "ma-rē", VariationType = "unknown" },
+                    new GedcomVariation { Value = "mer-ē", VariationType = "unknown" }
+                };
+
+            var romanizedVariations =
+                new GedcomRecordList<GedcomVariation>
+                {
+                    new GedcomVariation { Value = "Miriam" },
+                    new GedcomVariation { Value = "Maria" }
+                };
+
+            var name = new GedcomName
+            {
+                Type = "aka",
+                Prefix = "Miss",
+                Given = "Mary",
+                SurnamePrefix = "Neu",
+                Surname = "Neumann",
+                Suffix = "Jr",
+                Nick = "Polly",
+                PreferredName = true
+            };
+
+            name.PhoneticVariations.AddRange(phoneticVariations);
+            name.RomanizedVariations.AddRange(romanizedVariations);
+
+            return name;
         }
     }
 }

--- a/GeneGenie.Gedcom/GedcomAddress.cs
+++ b/GeneGenie.Gedcom/GedcomAddress.cs
@@ -509,12 +509,6 @@ namespace GeneGenie.Gedcom
                 return compare;
             }
 
-            compare = GedcomDate.CompareByDate(ChangeDate, otherAddress.ChangeDate);
-            if (compare != 0)
-            {
-                return compare;
-            }
-
             compare = string.Compare(City, otherAddress.City);
             if (compare != 0)
             {

--- a/GeneGenie.Gedcom/GedcomGenericListComparer.cs
+++ b/GeneGenie.Gedcom/GedcomGenericListComparer.cs
@@ -124,5 +124,42 @@ namespace GeneGenie.Gedcom
 
             return 0;
         }
+
+        /// <summary>
+        /// Compares two lists of records to see if they are equal.
+        /// The records must implement IComparable.
+        /// </summary>
+        /// <typeparam name="T">A type that implements IComparable.</typeparam>
+        /// <param name="list1">The first list of records.</param>
+        /// <param name="list2">The second list of records.</param>
+        /// <returns>
+        /// Returns an integer that indicates their relative position in the sort order.
+        /// </returns>
+        public static int CompareListOrder<T>(List<T> list1, List<T> list2)
+            where T : IComparable<T>
+        {
+            if (list1.Count > list2.Count)
+            {
+                return 1;
+            }
+
+            if (list1.Count < list2.Count)
+            {
+                return -1;
+            }
+
+            var sortedList1 = list1.OrderBy(n => n).ToList();
+            var sortedList2 = list2.OrderBy(n => n).ToList();
+            for (int i = 0; i < sortedList1.Count; i++)
+            {
+                var compare = sortedList1.ElementAt(i).CompareTo(sortedList2.ElementAt(i));
+                if (compare != 0)
+                {
+                    return compare;
+                }
+            }
+
+            return 0;
+        }
     }
 }

--- a/GeneGenie.Gedcom/GedcomIndividualRecord.cs
+++ b/GeneGenie.Gedcom/GedcomIndividualRecord.cs
@@ -35,7 +35,7 @@ namespace GeneGenie.Gedcom
     /// <summary>
     /// Details about a given individual.
     /// </summary>
-    public class GedcomIndividualRecord : GedcomRecord, IComparable, IComparable<GedcomIndividualRecord>
+    public class GedcomIndividualRecord : GedcomRecord, IComparable, IComparable<GedcomIndividualRecord>, IEquatable<GedcomIndividualRecord>
     {
         private GedcomRecordList<GedcomName> names;
         private GedcomSex sex;
@@ -734,6 +734,17 @@ namespace GeneGenie.Gedcom
         public int CompareTo(object individual)
         {
             return CompareTo(individual as GedcomIndividualRecord);
+        }
+
+        /// <summary>
+        /// Compares the current and passed individual to see if they are the same.
+        /// Compares using user submitted data, not the internal ids which may change.
+        /// </summary>
+        /// <param name="other">The other individual to compare the current individual against.</param>
+        /// <returns>True if they match, false otherwise.</returns>
+        public bool Equals(GedcomIndividualRecord other)
+        {
+            return CompareTo(other) == 0;
         }
 
         /// <summary>

--- a/GeneGenie.Gedcom/GedcomName.cs
+++ b/GeneGenie.Gedcom/GedcomName.cs
@@ -28,7 +28,7 @@ namespace GeneGenie.Gedcom
     /// A name for a given individual, allowing different variations to be
     /// stored.
     /// </summary>
-    public class GedcomName : GedcomRecord, IComparable<GedcomName>
+    public class GedcomName : GedcomRecord, IComparable<GedcomName>, IComparable, IEquatable<GedcomName>
     {
         private string type;
 
@@ -529,15 +529,97 @@ namespace GeneGenie.Gedcom
                 return 1;
             }
 
-            return string.Compare(Name, other.Name);
+            var compare = string.Compare(Type, other.Type);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = GedcomGenericListComparer.CompareListOrder(PhoneticVariations, other.PhoneticVariations);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = GedcomGenericListComparer.CompareListOrder(RomanizedVariations, other.RomanizedVariations);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Surname, other.Surname);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Prefix, other.Prefix);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Given, other.Given);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(SurnamePrefix, other.SurnamePrefix);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Suffix, other.Suffix);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(Nick, other.Nick);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = PreferredName.CompareTo(other.PreferredName);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            return compare;
         }
 
         /// <summary>
-        /// Compare the user entered data against the passed instance for similarity.
+        /// Compares two GedcomName instances by using the full name.
+        /// </summary>
+        /// <param name="obj">The name to compare against this instance.</param>
+        /// <returns>An integer specifying the relative sort order.</returns>
+        public int CompareTo(object obj)
+        {
+            return CompareTo(obj as GedcomName);
+        }
+
+        /// <summary>
+        /// Compare the user-entered data against the passed instance for similarity.
+        /// </summary>
+        /// <param name="other">The GedcomName to compare this instance against.</param>
+        /// <returns>
+        /// True if instance matches user data, otherwise False.
+        /// </returns>
+        public bool Equals(GedcomName other)
+        {
+            return CompareTo(other) == 0;
+        }
+
+        /// <summary>
+        /// Compare the user-entered data against the passed instance for similarity.
         /// </summary>
         /// <param name="obj">The object to compare this instance against.</param>
         /// <returns>
-        /// True if instance matches user data, otherwise false.
+        /// True if instance matches user data, otherwise False.
         /// </returns>
         public override bool IsEquivalentTo(object obj)
         {

--- a/GeneGenie.Gedcom/GedcomVariation.cs
+++ b/GeneGenie.Gedcom/GedcomVariation.cs
@@ -24,7 +24,7 @@ namespace GeneGenie.Gedcom
     /// <summary>
     /// TODO: Doc
     /// </summary>
-    public class GedcomVariation
+    public class GedcomVariation : IComparable<GedcomVariation>, IComparable, IEquatable<GedcomVariation>
     {
         ///// <summary>
         ///// TODO: Doc, why such a vague type?
@@ -116,6 +116,53 @@ namespace GeneGenie.Gedcom
         {
             get { return changeDate; }
             set { changeDate = value; }
+        }
+
+        /// <summary>
+        /// Compares the current and passed-in GedcomVariation to see if they are the same.
+        /// </summary>
+        /// <param name="other">The GedcomVariation to compare the current instance against.</param>
+        /// <returns>A 32-bit signed integer that indicates whether this instance precedes, follows, or appears in the same position in the sort order as the value parameter.</returns>
+        public int CompareTo(GedcomVariation other)
+        {
+            if (other == null)
+            {
+                return 1;
+            }
+
+            var compare = string.Compare(Value, other.Value);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = string.Compare(VariationType, other.VariationType);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            return compare;
+        }
+
+        /// <summary>
+        /// Compares the current and passed-in object to see if they are the same.
+        /// </summary>
+        /// <param name="obj">The object to compare the current instance against.</param>
+        /// <returns>A 32-bit signed integer that indicates whether this instance precedes, follows, or appears in the same position in the sort order as the value parameter.</returns>
+        public int CompareTo(object obj)
+        {
+            return CompareTo(obj as GedcomVariation);
+        }
+
+        /// <summary>
+        /// Compares the current and passed-in GedcomVariation to see if they are the same.
+        /// </summary>
+        /// <param name="other">The GedcomVariation to compare the current instance against.</param>
+        /// <returns>True if they match, False otherwise.</returns>
+        public bool Equals(GedcomVariation other)
+        {
+            return CompareTo(other) == 0;
         }
 
         /// <summary>


### PR DESCRIPTION
I didn't mean for this PR to be so big. The first four bullet points were supposed to be one PR, and the other three a second PR. Unfortunately I uploaded the additional changes to the branch and forgot they'd be merged into the existing PR.

References #10

* Removed "ChangeDate" from comparison logic in GedcomAddress.
* Removed associated "ChangeDate" test, but left one that makes sure "ChangeDate" is not a condition of equality.
* Added new method to GedcomGenericListComparer for comparing lists not derived from GedcomRecord.
* Implemented IEquatable on GedcomIndividualRecord.
* Implemented IComparable and IEquatable for GedcomName.
* Implemented IComparable and IEquatable for GedcomVariation.
* Added tests for both classes.