### PR TITLE
Adding more equality testing and unit tests around comparison.

### DIFF
--- a/GeneGenie.Gedcom.Tests/Individuals/GedcomIndividualComparisonTest.cs
+++ b/GeneGenie.Gedcom.Tests/Individuals/GedcomIndividualComparisonTest.cs
@@ -20,6 +20,7 @@
 namespace GeneGenie.Gedcom.Parser
 {
     using System.Collections.Generic;
+    using Gedcom.Enums;
     using Tests.DataHelperExtensions;
     using Xunit;
 
@@ -36,6 +37,34 @@ namespace GeneGenie.Gedcom.Parser
         public GedcomIndividualComparisonTest()
         {
             gedcomDb = new GedcomDatabase();
+        }
+
+        [Fact]
+        private void Individual_are_sorted_alphanumerically()
+        {
+            var person1 = gedcomDb.NamedPerson("1");
+            var person2 = gedcomDb.NamedPerson("2");
+
+            var li = new List<GedcomIndividualRecord> { person1, person2 };
+            li.Sort();
+
+            var sortOrder = person1.CompareTo(person2);
+
+            Assert.Equal(-1, sortOrder);
+        }
+
+        [Fact]
+        private void Individual_are_sorted_alphanumerically_when_reversed()
+        {
+            var person1 = gedcomDb.NamedPerson("1");
+            var person2 = gedcomDb.NamedPerson("2");
+
+            var li = new List<GedcomIndividualRecord> { person2, person1 };
+            li.Sort();
+
+            var sortOrder = person2.CompareTo(person1);
+
+            Assert.Equal(1, sortOrder);
         }
 
         [Fact]
@@ -91,6 +120,359 @@ namespace GeneGenie.Gedcom.Parser
             Assert.Equal(1, sortOrder);
         }
 
+        [Theory]
+        [InlineData("Mary", "Bob", "1")]
+        [InlineData("Bob", "Bob", "0")]
+        [InlineData("Bob", "Mary", "-1")]
+        private void Individuals_are_sorted_correctly_by_name(string name1, string name2, int expectedRelativePosition)
+        {
+            var person1 = gedcomDb.NamedPerson(name1);
+            var person2 = gedcomDb.NamedPerson(name2);
+
+            Assert.Equal(expectedRelativePosition, person1.CompareTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_different_names_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Sam");
+            var person2 = gedcomDb.NamedPerson("Kate");
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Fact]
+        private void Individuals_with_more_names_are_sorted_last()
+        {
+            var person1 = gedcomDb.NamedPerson("Bob");
+            var person2 = gedcomDb.NamedPerson("Bob");
+
+            person1.Names.Add(new GedcomName { Given = "Alice" });
+
+            Assert.Equal(1, person1.CompareTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_different_sex_are_not_similar()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+            person2.Sex = GedcomSex.Male;
+
+            Assert.False(person1.IsEquivalentTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_different_sex_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+            person2.Sex = GedcomSex.Male;
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Theory]
+        [InlineData(GedcomSex.NotSet, GedcomSex.Male, -1)]
+        [InlineData(GedcomSex.Male, GedcomSex.Male, 0)]
+        [InlineData(GedcomSex.Male, GedcomSex.NotSet, 1)]
+        private void Individuals_are_sorted_correctly_by_sex(GedcomSex sex1, GedcomSex sex2, int expectedRelativePosition)
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Sex = sex1;
+            person2.Sex = sex2;
+
+            Assert.Equal(expectedRelativePosition, person1.CompareTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_different_events_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Events.Add(new GedcomIndividualEvent { EventName = "Event A" });
+            person2.Events.Add(new GedcomIndividualEvent { EventName = "Event B" });
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Fact]
+        private void Individuals_with_different_number_of_events_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Events.Add(new GedcomIndividualEvent());
+            person1.Events.Add(new GedcomIndividualEvent());
+            person2.Events.Add(new GedcomIndividualEvent());
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Theory]
+        [InlineData("Event A", "Event B", -1)]
+        [InlineData("Event A", "Event A", 0)]
+        [InlineData("Event B", "Event A", 1)]
+        private void Individuals_are_sorted_correctly_by_event(string event1, string event2, int expectedRelativePosition)
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Events.Add(new GedcomIndividualEvent { EventName = event1 });
+            person2.Events.Add(new GedcomIndividualEvent { EventName = event2 });
+
+            Assert.Equal(expectedRelativePosition, person1.CompareTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_different_attributes_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Attributes.Add(new GedcomIndividualEvent { EventName = "Attributes A" });
+            person2.Attributes.Add(new GedcomIndividualEvent { EventName = "Attributes B" });
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Fact]
+        private void Individuals_with_different_number_of_attributes_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Attributes.Add(new GedcomIndividualEvent());
+            person1.Attributes.Add(new GedcomIndividualEvent());
+            person2.Attributes.Add(new GedcomIndividualEvent());
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Theory]
+        [InlineData("Attribute A", "Attribute B", -1)]
+        [InlineData("Attribute A", "Attribute A", 0)]
+        [InlineData("Attribute B", "Attribute A", 1)]
+        private void Individuals_are_sorted_correctly_by_attribute(string attribute1, string attribute2, int expectedRelativePosition)
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Events.Add(new GedcomIndividualEvent { EventName = attribute1 });
+            person2.Events.Add(new GedcomIndividualEvent { EventName = attribute2 });
+
+            Assert.Equal(expectedRelativePosition, person1.CompareTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_different_children_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.ChildIn.Add(new GedcomFamilyLink { Status = ChildLinkageStatus.Challenged });
+            person2.ChildIn.Add(new GedcomFamilyLink { Status = ChildLinkageStatus.Proven });
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Fact]
+        private void Individuals_with_different_number_of_children_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.ChildIn.Add(new GedcomFamilyLink());
+            person1.ChildIn.Add(new GedcomFamilyLink());
+            person2.ChildIn.Add(new GedcomFamilyLink());
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Theory]
+        [InlineData(ChildLinkageStatus.Unknown, ChildLinkageStatus.Challenged, -1)]
+        [InlineData(ChildLinkageStatus.Challenged, ChildLinkageStatus.Challenged, 0)]
+        [InlineData(ChildLinkageStatus.Challenged, ChildLinkageStatus.Unknown, 1)]
+        private void Individuals_are_sorted_correctly_by_child(ChildLinkageStatus status1, ChildLinkageStatus status2, int expectedRelativePosition)
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.ChildIn.Add(new GedcomFamilyLink { Status = status1 });
+            person2.ChildIn.Add(new GedcomFamilyLink { Status = status2 });
+
+            Assert.Equal(expectedRelativePosition, person1.CompareTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_different_spouses_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.SpouseIn.Add(new GedcomFamilyLink { Status = ChildLinkageStatus.Challenged });
+            person2.SpouseIn.Add(new GedcomFamilyLink { Status = ChildLinkageStatus.Proven });
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Fact]
+        private void Individuals_with_different_number_of_spouses_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.SpouseIn.Add(new GedcomFamilyLink());
+            person1.SpouseIn.Add(new GedcomFamilyLink());
+            person2.SpouseIn.Add(new GedcomFamilyLink());
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Theory]
+        [InlineData(false, true, -1)]
+        [InlineData(true, true, 0)]
+        [InlineData(true, false, 1)]
+        private void Individuals_are_sorted_correctly_by_spouse(bool pref1, bool pref2, int expectedRelativePosition)
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.SpouseIn.Add(new GedcomFamilyLink { PreferedSpouse = pref1 });
+            person2.SpouseIn.Add(new GedcomFamilyLink { PreferedSpouse = pref2 });
+
+            Assert.Equal(expectedRelativePosition, person1.CompareTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_different_associations_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Associations.Add(new GedcomAssociation { Description = "Godparent" });
+            person2.Associations.Add(new GedcomAssociation { Description = "Witness" });
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Fact]
+        private void Individuals_with_different_number_of_associations_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Associations.Add(new GedcomAssociation());
+            person1.Associations.Add(new GedcomAssociation());
+            person2.Associations.Add(new GedcomAssociation());
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Theory]
+        [InlineData("Godparent", "Witness", -1)]
+        [InlineData("Friend", "Friend", 0)]
+        [InlineData("Witness", "Godparent", 1)]
+        private void Individuals_are_sorted_correctly_by_association(string assoc1, string assoc2, int expectedRelativePosition)
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Associations.Add(new GedcomAssociation { Description = assoc1 });
+            person2.Associations.Add(new GedcomAssociation { Description = assoc2 });
+
+            Assert.Equal(expectedRelativePosition, person1.CompareTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_different_aliases_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Mary");
+            var person2 = gedcomDb.NamedPerson("Mary");
+
+            person1.Alia.Add("Miriam");
+            person2.Alia.Add("Maria");
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Fact]
+        private void Individuals_with_different_number_of_aliases_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Ryan");
+            var person2 = gedcomDb.NamedPerson("Ryan");
+
+            person1.Alia.Add(string.Empty);
+            person1.Alia.Add(string.Empty);
+            person2.Alia.Add(string.Empty);
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Theory]
+        [InlineData("Maria", "Miriam", -1)]
+        [InlineData("Poppy", "Poppy", 0)]
+        [InlineData("Miriam", "Maria", 1)]
+        private void Individuals_are_sorted_correctly_by_alias(string alias1, string alias2, int expectedRelativePosition)
+        {
+            var person1 = gedcomDb.NamedPerson("Mary");
+            var person2 = gedcomDb.NamedPerson("Mary");
+
+            person1.Alia.Add(alias1);
+            person2.Alia.Add(alias2);
+
+            Assert.Equal(expectedRelativePosition, person1.CompareTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_different_addresses_are_not_equal()
+        {
+            var person1 = gedcomDb.NamedPerson("Mary");
+            var person2 = gedcomDb.NamedPerson("Mary");
+
+            person1.Address = new GedcomAddress { Country = "United States" };
+            person2.Address = new GedcomAddress { Country = "Canada" };
+
+            Assert.NotEqual(person1, person2);
+        }
+
+        [Fact]
+        private void Individuals_with_fewer_notes_are_ordered_first()
+        {
+            var person1 = gedcomDb.NamedPerson("Mary");
+            var person2 = gedcomDb.NamedPerson("Mary");
+
+            person1.Notes.Add("Note 1");
+            person1.Notes.Add("Note 2");
+            person2.Notes.Add("Note 3");
+
+            Assert.Equal(1, person1.CompareTo(person2));
+        }
+
+        [Fact]
+        private void Individuals_with_same_note_text_are_equal()
+        {
+            var person1 = CreateIndividualForNoteTest("Same Note");
+            var person2 = CreateIndividualForNoteTest("Same Note");
+
+            Assert.Equal(person1, person2);
+        }
+
+        [Theory]
+        [InlineData("Aaaa", "Zzzz", -1)]
+        [InlineData("Note", "Note", 0)]
+        [InlineData("Zzzz", "Aaaa", 1)]
+        private void Individuals_are_sorted_correctly_by_note(string noteText1, string noteText2, int expectedRelativePosition)
+        {
+            var person1 = CreateIndividualForNoteTest(noteText1);
+            var person2 = CreateIndividualForNoteTest(noteText2);
+
+            Assert.Equal(expectedRelativePosition, person1.CompareTo(person2));
+        }
+
         [Fact]
         private void Individuals_with_same_facts_are_similar()
         {
@@ -111,46 +493,14 @@ namespace GeneGenie.Gedcom.Parser
             Assert.Equal(0, sortOrder);
         }
 
-        [Fact]
-        private void Individuals_with_different_sex_are_not_similar()
+        private GedcomIndividualRecord CreateIndividualForNoteTest(string noteText)
         {
-            var person1 = gedcomDb.NamedPerson("Ryan");
-            var person2 = gedcomDb.NamedPerson("Ryan");
-            person2.Sex = Gedcom.Enums.GedcomSex.Male;
-
-            Assert.False(person1.IsEquivalentTo(person2));
-        }
-
-        [Fact]
-        private void Individuals_with_different_sex_are_not_equal()
-        {
-            var person1 = gedcomDb.NamedPerson("Ryan");
-            var person2 = gedcomDb.NamedPerson("Ryan");
-            person2.Sex = Gedcom.Enums.GedcomSex.Male;
-
-            Assert.NotEqual(person1, person2);
-        }
-
-        [Fact]
-        private void Individual_are_sorted_alphanumerically()
-        {
-            var person1 = gedcomDb.NamedPerson("1");
-            var person2 = gedcomDb.NamedPerson("2");
-
-            var sortOrder = person1.CompareTo(person2);
-
-            Assert.Equal(-1, sortOrder);
-        }
-
-        [Fact]
-        private void Individual_are_sorted_alphanumerically_when_reversed()
-        {
-            var person1 = gedcomDb.NamedPerson("1");
-            var person2 = gedcomDb.NamedPerson("2");
-
-            var sortOrder = person2.CompareTo(person1);
-
-            Assert.Equal(1, sortOrder);
+            var xrefId = gedcomDb.GenerateXref("NOTE");
+            var note = new GedcomNoteRecord { Database = gedcomDb, XRefID = xrefId, Text = noteText };
+            gedcomDb.Add(xrefId, note);
+            var person = gedcomDb.NamedPerson("Mary");
+            person.Notes.Add(xrefId);
+            return person;
         }
     }
 }

--- a/GeneGenie.Gedcom.Tests/Individuals/GedcomIndividualComparisonTest.cs
+++ b/GeneGenie.Gedcom.Tests/Individuals/GedcomIndividualComparisonTest.cs
@@ -476,8 +476,8 @@ namespace GeneGenie.Gedcom.Parser
         [Fact]
         private void Individuals_with_same_facts_are_similar()
         {
-            var person1 = gedcomDb.NamedPerson("Ryan");
-            var person2 = gedcomDb.NamedPerson("Ryan");
+            var person1 = GenerateCompleteIndividual();
+            var person2 = GenerateCompleteIndividual();
 
             Assert.True(person1.IsEquivalentTo(person2));
         }
@@ -485,8 +485,8 @@ namespace GeneGenie.Gedcom.Parser
         [Fact]
         private void Individuals_with_same_facts_are_sorted_equally()
         {
-            var person1 = gedcomDb.NamedPerson("Ryan");
-            var person2 = gedcomDb.NamedPerson("Ryan");
+            var person1 = GenerateCompleteIndividual();
+            var person2 = GenerateCompleteIndividual();
 
             var sortOrder = person1.CompareTo(person2);
 
@@ -500,6 +500,28 @@ namespace GeneGenie.Gedcom.Parser
             gedcomDb.Add(xrefId, note);
             var person = gedcomDb.NamedPerson("Mary");
             person.Notes.Add(xrefId);
+            return person;
+        }
+
+        private GedcomIndividualRecord GenerateCompleteIndividual()
+        {
+            var person = gedcomDb.NamedPerson("John");
+
+            person.Sex = GedcomSex.Male;
+            person.Events.Add(new GedcomIndividualEvent { EventName = "Event A" });
+            person.Events.Add(new GedcomIndividualEvent { EventName = "Event B" });
+            person.Attributes.Add(new GedcomIndividualEvent { EventName = "Attribute A" });
+            person.Attributes.Add(new GedcomIndividualEvent { EventName = "Attribute B" });
+            person.ChildIn.Add(new GedcomFamilyLink { Pedigree = PedigreeLinkageType.Birth });
+            person.ChildIn.Add(new GedcomFamilyLink { Pedigree = PedigreeLinkageType.Unknown });
+            person.SpouseIn.Add(new GedcomFamilyLink { Pedigree = PedigreeLinkageType.Unknown });
+            person.SpouseIn.Add(new GedcomFamilyLink { Pedigree = PedigreeLinkageType.Birth });
+            person.Associations.Add(new GedcomAssociation { Description = "Some association." });
+            person.Associations.Add(new GedcomAssociation { Description = "Another association." });
+            person.Alia.Add("Jonathon");
+            person.Alia.Add("Jon");
+            person.Address = new GedcomAddress { Country = "United States", State = "CA" };
+
             return person;
         }
     }

--- a/GeneGenie.Gedcom/GedcomAssociation.cs
+++ b/GeneGenie.Gedcom/GedcomAssociation.cs
@@ -166,13 +166,13 @@ namespace GeneGenie.Gedcom
                 return 1;
             }
 
-            var compare = string.Compare(other.Description, Description);
+            var compare = string.Compare(Description, other.Description);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = string.Compare(other.Individual, Individual);
+            compare = string.Compare(Individual, other.Individual);
             if (compare != 0)
             {
                 return compare;

--- a/GeneGenie.Gedcom/GedcomEvent.cs
+++ b/GeneGenie.Gedcom/GedcomEvent.cs
@@ -28,7 +28,7 @@ namespace GeneGenie.Gedcom
     /// <summary>
     /// Defines a generic event or fact
     /// </summary>
-    public class GedcomEvent : GedcomRecord, IComparable
+    public class GedcomEvent : GedcomRecord, IComparable, IComparable<GedcomEvent>
     {
         private static string[] typeStrings = new string[]
         {
@@ -635,30 +635,32 @@ namespace GeneGenie.Gedcom
         /// <returns>Relative position in the sort order.</returns>
         public int CompareTo(object obj)
         {
-            var eventToCompare = obj as GedcomEvent;
+            return CompareTo(obj as GedcomEvent);
+        }
 
+        /// <summary>
+        /// Compares two events to see if the date and place are the same.
+        /// </summary>
+        /// <param name="eventToCompare">The event instance to compare against.</param>
+        /// <returns>Relative position in the sort order.</returns>
+        public int CompareTo(GedcomEvent eventToCompare)
+        {
             if (eventToCompare == null)
             {
                 return -1;
             }
 
-            if (eventToCompare.Date == null && Date == null)
-            {
-                return 0;
-            }
-
-            if (eventToCompare.Date == null)
+            if (eventToCompare.Date == null && Date != null)
             {
                 return -1;
             }
 
-            if (Date == null)
+            if (Date == null && eventToCompare.Date != null)
             {
-                return 1;
+                return -1;
             }
 
             var compare = GedcomDate.CompareByDate(Date, eventToCompare.Date);
-
             if (compare != 0)
             {
                 return compare;

--- a/GeneGenie.Gedcom/GedcomFamilyLink.cs
+++ b/GeneGenie.Gedcom/GedcomFamilyLink.cs
@@ -232,31 +232,31 @@ namespace GeneGenie.Gedcom
                 return 1;
             }
 
-            var compare = link.FatherPedigree.CompareTo(FatherPedigree);
+            var compare = FatherPedigree.CompareTo(link.FatherPedigree);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = link.MotherPedigree.CompareTo(MotherPedigree);
+            compare = MotherPedigree.CompareTo(link.MotherPedigree);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = link.Pedigree.CompareTo(Pedigree);
+            compare = Pedigree.CompareTo(link.Pedigree);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = link.PreferedSpouse.CompareTo(PreferedSpouse);
+            compare = PreferedSpouse.CompareTo(link.PreferedSpouse);
             if (compare != 0)
             {
                 return compare;
             }
 
-            compare = link.Status.CompareTo(Status);
+            compare = Status.CompareTo(link.Status);
             if (compare != 0)
             {
                 return compare;

--- a/GeneGenie.Gedcom/GedcomGenericComparer.cs
+++ b/GeneGenie.Gedcom/GedcomGenericComparer.cs
@@ -1,0 +1,42 @@
+﻿namespace GeneGenie.Gedcom
+{
+    using System;
+
+    /// <summary>
+    /// Compares two objects for equality.
+    /// </summary>
+    public class GedcomGenericComparer
+    {
+        /// <summary>
+        /// Compares two records to see if they are equal.
+        /// Safely handles one or both being null.
+        /// The records must implement IComparable.
+        /// </summary>
+        /// <typeparam name="T">A type that implements IComparable.</typeparam>
+        /// <param name="item1">The first record.</param>
+        /// <param name="item2">The second record.</param>
+        /// <returns>
+        /// Returns an integer that indicates their relative position in the sort order.
+        /// </returns>
+        public static int SafeCompareOrder<T>(T item1, T item2)
+            where T : IComparable<T>
+        {
+            if (item1 == null && item2 == null)
+            {
+                return 0;
+            }
+            else if (item2 == null)
+            {
+                return -1;
+            }
+            else if (item1 == null)
+            {
+                return 1;
+            }
+            else
+            {
+                return item1.CompareTo(item2);
+            }
+        }
+    }
+}

--- a/GeneGenie.Gedcom/GedcomIndividualRecord.cs
+++ b/GeneGenie.Gedcom/GedcomIndividualRecord.cs
@@ -21,7 +21,6 @@
 
 namespace GeneGenie.Gedcom
 {
-
     using System;
     using System.Globalization;
     using System.IO;
@@ -698,6 +697,18 @@ namespace GeneGenie.Gedcom
         /// <returns>A 32-bit signed integer that indicates whether this instance precedes, follows, or appears in the same position in the sort order as the value parameter.</returns>
         public int CompareTo(GedcomIndividualRecord individual)
         {
+            /* SubmitterRecords was omitted from comparison.
+             * It stores XRefId values to individuals who contribute genealogical
+             * data to a file, which doesn't contribute to equality of an individual.
+             *
+             * ANCI and DESI were also omitted from comparison.
+             * These fields indicate interest in additional research for
+             * ancestors and descendants, and don't contribute to equality.
+             *
+             * Assocations are links to relatives, godparents, etc.
+             * They're part of the comparison currently, but not sure if they should be.
+             */
+
             if (individual == null)
             {
                 return 1;
@@ -709,18 +720,54 @@ namespace GeneGenie.Gedcom
                 return compare;
             }
 
-            compare = CompareEvents(individual.Events);
+            compare = Sex.CompareTo(individual.Sex);
             if (compare != 0)
             {
                 return compare;
             }
 
-            if (individual.Sex != Sex)
+            compare = CompareEvents(Events, individual.Events);
+            if (compare != 0)
             {
-                return individual.Sex.CompareTo(Sex);
+                return compare;
             }
 
-            // TODO: Put more property tests in here.
+            compare = CompareEvents(Attributes, individual.Attributes);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = GedcomGenericListComparer.CompareListSortOrders(ChildIn, individual.ChildIn);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = GedcomGenericListComparer.CompareListSortOrders(SpouseIn, individual.SpouseIn);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = GedcomGenericListComparer.CompareListSortOrders(Associations, individual.Associations);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = GedcomGenericListComparer.CompareListOrder(Alia, individual.Alia);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
+            compare = GedcomGenericComparer.SafeCompareOrder(Address, individual.Address);
+            if (compare != 0)
+            {
+                return compare;
+            }
+
             return CompareNotes(individual);
         }
 
@@ -1556,40 +1603,25 @@ namespace GeneGenie.Gedcom
             }
         }
 
-        private int CompareEvents(GedcomRecordList<GedcomIndividualEvent> events)
+        private int CompareEvents(GedcomRecordList<GedcomIndividualEvent> thisEvents, GedcomRecordList<GedcomIndividualEvent> otherEvents)
         {
             // TODO: This is a long winded and non-reusable way of comparing two lists. Can we use a generic comparer?
-            if (events.Count < Events.Count)
-            {
-                return -1;
-            }
-
-            if (events.Count > Events.Count)
+            if (thisEvents.Count > otherEvents.Count)
             {
                 return 1;
             }
 
-            for (int i = 0; i < events.Count(); i++)
+            if (otherEvents.Count > thisEvents.Count)
             {
-                var indiEv = events.ElementAt(i);
-                var ev = Events.ElementAt(i);
+                return -1;
+            }
 
-                if (indiEv == null && ev == null)
-                {
-                    return 0;
-                }
+            for (int i = 0; i < otherEvents.Count(); i++)
+            {
+                var otherEvent = otherEvents.ElementAt(i);
+                var thisEvent = thisEvents.ElementAt(i);
 
-                if (indiEv == null)
-                {
-                    return -1;
-                }
-
-                if (ev == null)
-                {
-                    return 1;
-                }
-
-                var compare = indiEv.CompareTo(ev);
+                var compare = GedcomGenericComparer.SafeCompareOrder(thisEvent, otherEvent);
                 if (compare != 0)
                 {
                     return compare;
@@ -1602,14 +1634,14 @@ namespace GeneGenie.Gedcom
         private int CompareNotes(GedcomIndividualRecord individual)
         {
             // TODO: This is a long winded and non-reusable way of comparing two lists. Can we use a generic comparer and place this into the GedcomNote class?
-            if (Notes.Count < individual.Notes.Count)
-            {
-                return -1;
-            }
-
             if (Notes.Count > individual.Notes.Count)
             {
                 return 1;
+            }
+
+            if (Notes.Count < individual.Notes.Count)
+            {
+                return -1;
             }
 
             var indiList = individual.Notes.OrderBy(noteXRef => noteXRef);
@@ -1637,7 +1669,7 @@ namespace GeneGenie.Gedcom
                 }
 
                 var indiNoteUtf8 = System.Text.Encoding.UTF8.GetString(System.Text.Encoding.Default.GetBytes(indiNote.Text));
-                var compare = string.Compare(indiNoteUtf8, note.Text);
+                var compare = string.Compare(note.Text, indiNoteUtf8);
                 if (compare != 0)
                 {
                     return compare;

--- a/GeneGenie.Gedcom/GeneGenie.Gedcom.csproj
+++ b/GeneGenie.Gedcom/GeneGenie.Gedcom.csproj
@@ -151,6 +151,7 @@
     <Compile Include="GedcomFamilyEvent.cs" />
     <Compile Include="GedcomFamilyLink.cs" />
     <Compile Include="GedcomFamilyRecord.cs" />
+    <Compile Include="GedcomGenericComparer.cs" />
     <Compile Include="GedcomHeader.cs" />
     <Compile Include="GedcomIndividualEvent.cs" />
     <Compile Include="GedcomIndividualRecord.cs" />


### PR DESCRIPTION
References #10

* Added equality testing to GedcomIndividualRecord. Left several properties out of the comparison (comments in the CompareTo method) that seem not to contribute to equality.
* Reversed comparisons of properties in GedcomFamilyLink and
GedcomAssociation after confirming correct behavior with tests.
* Fixed an issue in GedcomEvent that was immediately returning 0 when two
dates were null, without checking for equality on other properties.
* There's several places where similar checks are performed on two objects; moved code into a new GedcomGenericComparer class.